### PR TITLE
Add interactive admin panel controls

### DIFF
--- a/flyzexbot/localization.py
+++ b/flyzexbot/localization.py
@@ -67,6 +67,16 @@ class TextPack:
     dm_language_updated: str
     group_refresh_button: str
     dm_admin_panel_intro: str
+    dm_admin_panel_view_applications_button: str
+    dm_admin_panel_view_members_button: str
+    dm_admin_panel_add_admin_button: str
+    dm_admin_panel_more_tools_button: str
+    dm_admin_panel_back_button: str
+    dm_admin_panel_members_header: str
+    dm_admin_panel_members_empty: str
+    dm_admin_panel_add_admin_prompt: str
+    dm_admin_panel_more_tools_text: str
+    dm_admin_panel_more_tools_no_webapp: str
 
 
 PERSIAN_TEXTS = TextPack(
@@ -165,7 +175,25 @@ PERSIAN_TEXTS = TextPack(
     group_refresh_button="🔄 تازه‌سازی",
     dm_admin_panel_intro=(
         "<b>🛡️ پنل مدیریت فلیزکس</b>\n"
-        "آخرین درخواست‌های در انتظار بررسی در زیر نمایش داده می‌شوند."
+        "برای ادامه یکی از گزینه‌های شیشه‌ای زیر را انتخاب کنید."
+    ),
+    dm_admin_panel_view_applications_button="مشاهده درخواست‌ها",
+    dm_admin_panel_view_members_button="اعضای تایید‌شده",
+    dm_admin_panel_add_admin_button="افزودن ادمین جدید",
+    dm_admin_panel_more_tools_button="ابزارهای بیشتر",
+    dm_admin_panel_back_button="بازگشت به خانه",
+    dm_admin_panel_members_header="✅ اعضای تایید‌شده ({count} نفر):\n{members}",
+    dm_admin_panel_members_empty="هنوز هیچ عضوی تایید نشده است.",
+    dm_admin_panel_add_admin_prompt=(
+        "برای افزودن ادمین جدید، شناسه عددی او را ارسال کنید."
+        "\nدر صورت انصراف، دستور /cancel را ارسال کنید."
+    ),
+    dm_admin_panel_more_tools_text=(
+        "✨ برای مدیریت پیشرفته می‌توانید از پنل وب یا دستورات /pending و /admins استفاده کنید."
+        "\n🌐 لینک پنل وب: {webapp_url}"
+    ),
+    dm_admin_panel_more_tools_no_webapp=(
+        "✨ برای مدیریت پیشرفته از دستورات /pending و /admins استفاده کنید."
     ),
 )
 
@@ -266,7 +294,25 @@ ENGLISH_TEXTS = TextPack(
     group_refresh_button="🔄 Refresh",
     dm_admin_panel_intro=(
         "<b>🛡️ Flyzex admin panel</b>\n"
-        "Pending applications appear below for quick review."
+        "Choose one of the glassy options below to continue."
+    ),
+    dm_admin_panel_view_applications_button="View applications",
+    dm_admin_panel_view_members_button="Approved members",
+    dm_admin_panel_add_admin_button="Add new admin",
+    dm_admin_panel_more_tools_button="More tools",
+    dm_admin_panel_back_button="Back to home",
+    dm_admin_panel_members_header="✅ Approved members ({count}):\n{members}",
+    dm_admin_panel_members_empty="No members have been approved yet.",
+    dm_admin_panel_add_admin_prompt=(
+        "Send the numeric user ID you want to promote as an admin."
+        "\nSend /cancel if you changed your mind."
+    ),
+    dm_admin_panel_more_tools_text=(
+        "✨ For advanced management, open the web panel or use /pending and /admins."
+        "\n🌐 Web panel link: {webapp_url}"
+    ),
+    dm_admin_panel_more_tools_no_webapp=(
+        "✨ Use /pending and /admins for advanced management options."
     ),
 )
 

--- a/flyzexbot/services/storage.py
+++ b/flyzexbot/services/storage.py
@@ -197,6 +197,13 @@ class Storage:
     def get_application_status(self, user_id: int) -> Optional[ApplicationHistoryEntry]:
         return self._state.application_history.get(user_id)
 
+    def get_applicants_by_status(self, status: str) -> List[tuple[int, ApplicationHistoryEntry]]:
+        return [
+            (user_id, history)
+            for user_id, history in self._state.application_history.items()
+            if history.status == status
+        ]
+
     async def add_xp(self, chat_id: int, user_id: int, amount: int) -> int:
         async with self._lock:
             chat_key = str(chat_id)

--- a/flyzexbot/ui/keyboards.py
+++ b/flyzexbot/ui/keyboards.py
@@ -62,6 +62,60 @@ def glass_dm_welcome_keyboard(
     return InlineKeyboardMarkup(rows)
 
 
+def admin_panel_keyboard(
+    texts: TextPack | None = None,
+    webapp_url: str | None = None,
+) -> InlineKeyboardMarkup:
+    text_pack = texts or PERSIAN_TEXTS
+    rows: list[list[InlineKeyboardButton]] = [
+        [
+            InlineKeyboardButton(
+                text=f"📬 {text_pack.dm_admin_panel_view_applications_button}",
+                callback_data="admin_panel:view_applications",
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                text=f"✅ {text_pack.dm_admin_panel_view_members_button}",
+                callback_data="admin_panel:view_members",
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                text=f"➕ {text_pack.dm_admin_panel_add_admin_button}",
+                callback_data="admin_panel:add_admin",
+            )
+        ],
+    ]
+    if webapp_url:
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    text=f"🌐 {text_pack.dm_admin_panel_more_tools_button}",
+                    web_app=WebAppInfo(url=webapp_url),
+                )
+            ]
+        )
+    else:
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    text=f"✨ {text_pack.dm_admin_panel_more_tools_button}",
+                    callback_data="admin_panel:more_tools",
+                )
+            ]
+        )
+    rows.append(
+        [
+            InlineKeyboardButton(
+                text=f"⬅️ {text_pack.dm_admin_panel_back_button}",
+                callback_data="admin_panel:back",
+            )
+        ]
+    )
+    return InlineKeyboardMarkup(rows)
+
+
 def application_review_keyboard(user_id: int, texts: TextPack | None = None) -> InlineKeyboardMarkup:
     text_pack = texts or PERSIAN_TEXTS
     return InlineKeyboardMarkup(


### PR DESCRIPTION
## Summary
- implement a dedicated admin panel inline keyboard with application, member, and admin management options
- extend DM handler logic, localization, and storage utilities to support the new admin workflows
- add comprehensive tests to cover the updated admin panel interactions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68df554a5ef48324b9b0fdb5f0aee769