### PR TITLE
Enhance Persian localization defaults

### DIFF
--- a/flyzexbot/localization.py
+++ b/flyzexbot/localization.py
@@ -77,6 +77,7 @@ class TextPack:
     dm_admin_panel_add_admin_prompt: str
     dm_admin_panel_more_tools_text: str
     dm_admin_panel_more_tools_no_webapp: str
+    language_names: Dict[str, str]
 
 
 PERSIAN_TEXTS = TextPack(
@@ -124,8 +125,8 @@ PERSIAN_TEXTS = TextPack(
         "approve": "✅ درخواست کاربر تأیید و پیام ارسال شد.",
         "deny": "❌ درخواست کاربر رد و پیام ارسال شد.",
     },
-    dm_application_note_skip_hint="برای ادامه بدون توضیح، عبارت SKIP را ارسال کنید.",
-    dm_application_note_skip_keyword="skip",
+    dm_application_note_skip_hint="برای ادامه بدون توضیح، عبارت «صرفنظر» را ارسال کنید.",
+    dm_application_note_skip_keyword="صرفنظر",
     dm_application_note_label="یادداشت",
     dm_application_note_no_active="ℹ️ موردی برای ثبت یادداشت وجود ندارد.",
     dm_status_none="ℹ️ هنوز درخواستی ثبت نکرده‌اید.",
@@ -195,6 +196,10 @@ PERSIAN_TEXTS = TextPack(
     dm_admin_panel_more_tools_no_webapp=(
         "✨ برای مدیریت پیشرفته از دستورات /pending و /admins استفاده کنید."
     ),
+    language_names={
+        "fa": "فارسی",
+        "en": "انگلیسی",
+    },
 )
 
 
@@ -314,6 +319,10 @@ ENGLISH_TEXTS = TextPack(
     dm_admin_panel_more_tools_no_webapp=(
         "✨ Use /pending and /admins for advanced management options."
     ),
+    language_names={
+        "fa": "Persian",
+        "en": "English",
+    },
 )
 
 

--- a/flyzexbot/ui/keyboards.py
+++ b/flyzexbot/ui/keyboards.py
@@ -5,7 +5,8 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup, WebAppInfo
 from ..localization import PERSIAN_TEXTS, TextPack
 
 
-LANGUAGE_OPTIONS: list[tuple[str, str]] = [("fa", "فارسی"), ("en", "English")]
+LANGUAGE_CODES: tuple[str, ...] = ("fa", "en")
+DEFAULT_LANGUAGE_LABELS: dict[str, str] = {"fa": "فارسی", "en": "English"}
 
 
 def glass_dm_welcome_keyboard(
@@ -143,7 +144,9 @@ def application_review_keyboard(user_id: int, texts: TextPack | None = None) -> 
 def language_options_keyboard(active: str | None, texts: TextPack | None = None) -> InlineKeyboardMarkup:
     text_pack = texts or PERSIAN_TEXTS
     rows: list[list[InlineKeyboardButton]] = []
-    for code, label in LANGUAGE_OPTIONS:
+    for code in LANGUAGE_CODES:
+        language_names = getattr(text_pack, "language_names", {})
+        label = language_names.get(code, DEFAULT_LANGUAGE_LABELS.get(code, code))
         prefix = "✅ " if code == active else ""
         rows.append(
             [

--- a/tests/test_dm_handlers.py
+++ b/tests/test_dm_handlers.py
@@ -542,7 +542,7 @@ def test_admin_handles_skip_for_denial() -> None:
 
     asyncio.run(handler.handle_application_action(update, context))
 
-    note_message = DummyIncomingMessage("SkIp")
+    note_message = DummyIncomingMessage("  صرفنظر  ")
     update_note = SimpleNamespace(message=note_message, effective_user=admin_user)
 
     asyncio.run(handler.receive_application(update_note, context))


### PR DESCRIPTION
## Summary
- translate the Persian skip instruction and keyword used during application reviews
- expose localized language names in each text pack and update the language menu to use them
- adjust tests to cover the localized skip keyword

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68df5725304c83248c087f11337de404