### PR TITLE
Handle zero XP rewards in group tracker

### DIFF
--- a/config/settings.example.yaml
+++ b/config/settings.example.yaml
@@ -5,7 +5,7 @@ telegram:
   owner_id: 123456789  # شناسه مدیر اصلی بات
   application_review_chat: null  # در صورت نیاز می‌توانید شناسه چت خاصی برای اعلان درخواست‌ها تعیین کنید
 xp:
-  message_reward: 5
+  message_reward: 5  # در صورت تنظیم مقدار 0، سیستم XP در گروه غیرفعال می‌شود
   leaderboard_size: 10
 cups:
   leaderboard_size: 5

--- a/flyzexbot/handlers/group.py
+++ b/flyzexbot/handlers/group.py
@@ -59,6 +59,9 @@ class GroupHandlers:
             LOGGER.error("Failed to update XP for %s: %s", update.effective_user.id, exc)
             await self.analytics.record("group.activity_error")
             return
+        if self.xp_reward <= 0:
+            await self.analytics.record("group.activity_tracked")
+            return
         if new_score % (self.xp_reward * 5) == 0:
             await message.reply_text(
                 texts.group_xp_updated.format(

--- a/tests/test_group_handlers.py
+++ b/tests/test_group_handlers.py
@@ -17,6 +17,15 @@ class DummyChat:
         self.messages.append(text)
 
 
+class DummyMessage:
+    def __init__(self, text: str = "hello") -> None:
+        self.text = text
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str, **_: object) -> None:  # noqa: ANN003 - kwargs unused
+        self.replies.append(text)
+
+
 class DummyUser:
     def __init__(self, user_id: int = 456, language_code: str = "fa") -> None:
         self.id = user_id
@@ -48,3 +57,33 @@ def test_add_cup_accepts_single_argument_string() -> None:
 
     storage.add_cup.assert_awaited_once_with(chat.id, "Title", "Description", ["A", "B", "C"])
     assert PERSIAN_TEXTS.group_add_cup_usage not in chat.messages
+
+
+def test_track_activity_handles_zero_reward() -> None:
+    storage = SimpleNamespace(add_xp=AsyncMock(return_value=0))
+    handler = GroupHandlers(
+        storage=storage,
+        xp_reward=0,
+        xp_limit=100,
+        cups_limit=10,
+    )
+
+    message = DummyMessage()
+    chat = SimpleNamespace(id=789)
+    user = SimpleNamespace(id=321, full_name="Tester", username="tester")
+    update = SimpleNamespace(
+        effective_message=message,
+        effective_chat=chat,
+        effective_user=user,
+    )
+    context = DummyContext([])
+
+    asyncio.run(handler.track_activity(update, context))
+
+    storage.add_xp.assert_awaited_once()
+    assert storage.add_xp.await_args.kwargs == {
+        "chat_id": chat.id,
+        "user_id": user.id,
+        "amount": 0,
+    }
+    assert message.replies == []


### PR DESCRIPTION
## Summary
- short-circuit group XP milestone checks when rewards are non-positive to avoid modulo errors
- add a regression test covering zero XP rewards
- document how to disable XP via configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e175ad75b483248910665448f7f392