### PR TITLE
Fix XP milestone interval handling in group activity

### DIFF
--- a/flyzexbot/handlers/group.py
+++ b/flyzexbot/handlers/group.py
@@ -63,10 +63,11 @@ class GroupHandlers:
             LOGGER.error("Failed to update XP for %s: %s", update.effective_user.id, exc)
             await self.analytics.record("group.activity_error")
             return
-        if self.xp_reward <= 0:
+        if self.xp_reward <= 0 or self.milestone_interval <= 0:
             await self.analytics.record("group.activity_tracked")
             return
-        if new_score % (self.xp_reward * 5) == 0:
+        milestone_score = self.xp_reward * self.milestone_interval
+        if milestone_score > 0 and new_score % milestone_score == 0:
             await message.reply_text(
                 texts.group_xp_updated.format(
                     full_name=update.effective_user.full_name


### PR DESCRIPTION
## Summary
- respect the configured milestone interval when checking group XP milestones

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e17c4bad488324afd753db89f21072