### PR TITLE
Respect stored language preferences

### DIFF
--- a/flyzexbot/handlers/group.py
+++ b/flyzexbot/handlers/group.py
@@ -9,7 +9,8 @@ from telegram.constants import ParseMode
 from telegram.ext import (CallbackQueryHandler, CommandHandler, ContextTypes,
                           MessageHandler, filters)
 
-from ..localization import PERSIAN_TEXTS, TextPack, get_text_pack, normalize_language_code
+from ..localization import (AVAILABLE_LANGUAGE_CODES, PERSIAN_TEXTS, TextPack,
+                            get_text_pack, normalize_language_code)
 from ..services.analytics import AnalyticsTracker, NullAnalytics
 from ..services.storage import Storage
 from ..ui.keyboards import leaderboard_refresh_keyboard
@@ -182,18 +183,28 @@ class GroupHandlers:
         language_code: str | None = None,
     ) -> TextPack:
         chat_data = getattr(context, "chat_data", None)
-        stored_language = None
+        stored_language: str | None = None
+        stored_pack: TextPack | None = None
         if isinstance(chat_data, dict):
-            stored_language = chat_data.get("preferred_language")
+            maybe_stored = chat_data.get("preferred_language")
+            if isinstance(maybe_stored, str):
+                normalised_stored = normalize_language_code(maybe_stored) or maybe_stored
+                if normalised_stored in AVAILABLE_LANGUAGE_CODES:
+                    stored_language = normalised_stored
+                    stored_pack = get_text_pack(stored_language)
+                    if normalised_stored != maybe_stored:
+                        chat_data["preferred_language"] = normalised_stored
 
         normalised = normalize_language_code(language_code)
         if normalised:
-            if isinstance(chat_data, dict):
+            if stored_pack:
+                return stored_pack
+            if normalised in AVAILABLE_LANGUAGE_CODES and isinstance(chat_data, dict):
                 chat_data["preferred_language"] = normalised
             return get_text_pack(normalised)
 
-        if isinstance(stored_language, str):
-            return get_text_pack(stored_language)
+        if stored_pack:
+            return stored_pack
 
         return get_text_pack(None)
 

--- a/flyzexbot/localization.py
+++ b/flyzexbot/localization.py
@@ -333,6 +333,8 @@ _TEXT_PACKS: Dict[str, TextPack] = {
     "en": ENGLISH_TEXTS,
 }
 
+AVAILABLE_LANGUAGE_CODES = tuple(_TEXT_PACKS.keys())
+
 
 def normalize_language_code(language_code: str | None) -> str | None:
     if not language_code:


### PR DESCRIPTION
## Summary
- ensure stored DM and group language selection prioritizes saved preferences over Telegram locale changes
- normalize and validate persisted language codes against the supported set so Persian remains the default fallback

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e25f011c648324a3567954e0dee749