### PR TITLE
Fix LRUCache pop default handling

### DIFF
--- a/cachetools/__init__.py
+++ b/cachetools/__init__.py
@@ -8,7 +8,7 @@ the optional dependency is not possible due to network restrictions.
 from __future__ import annotations
 
 from collections import OrderedDict
-from typing import Iterable, Iterator, MutableMapping, Tuple, TypeVar
+from typing import Iterable, Iterator, MutableMapping, Tuple, TypeVar, overload, cast
 
 KT = TypeVar("KT")
 VT = TypeVar("VT")
@@ -53,13 +53,23 @@ class LRUCache(MutableMapping[KT, VT]):
     def values(self) -> Iterable[VT]:
         return self._store.values()
 
-    def pop(self, key: KT, default: VT | None = None) -> VT:
+    _MISSING = object()
+
+    @overload
+    def pop(self, key: KT) -> VT:
+        ...
+
+    @overload
+    def pop(self, key: KT, default: VT) -> VT:
+        ...
+
+    def pop(self, key: KT, default: VT | object = _MISSING) -> VT:
         if key in self._store:
             value = self._store.pop(key)
             return value
-        if default is not None:
-            return default
-        raise KeyError(key)
+        if default is self._MISSING:
+            raise KeyError(key)
+        return cast(VT, default)
 
     def popitem(self) -> Tuple[KT, VT]:
         return self._store.popitem()

--- a/tests/test_cachetools.py
+++ b/tests/test_cachetools.py
@@ -1,0 +1,11 @@
+from cachetools import LRUCache
+
+
+def test_lru_cache_pop_default_none_returns_none():
+    cache = LRUCache(maxsize=2)
+    assert cache.pop("missing", None) is None
+
+
+def test_lru_cache_pop_default_value_returned_when_missing():
+    cache = LRUCache(maxsize=2)
+    assert cache.pop("missing", "fallback") == "fallback"


### PR DESCRIPTION
## Summary
- ensure the local LRUCache implementation mirrors dict.pop semantics when a default is provided
- add regression tests covering missing-key pop with explicit defaults

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68e26fb2ee808324a47157ee5d64ca4a