### PR TITLE
Add username visibility to admin application reviews

### DIFF
--- a/flyzexbot/handlers/dm.py
+++ b/flyzexbot/handlers/dm.py
@@ -275,6 +275,7 @@ class DMHandlers:
                 success = await self.storage.add_application(
                     user_id=user.id,
                     full_name=user.full_name or user.username or str(user.id),
+                    username=getattr(user, "username", None),
                     answer=answer,
                     language_code=context.user_data.get("preferred_language"),
                 )
@@ -763,10 +764,18 @@ class DMHandlers:
 
     def _format_application_entry(self, application: Application, texts: TextPack) -> str:
         full_name = escape(str(application.full_name))
+        username = application.username
+        if username:
+            username = username.lstrip("@")
+            username_display = f"@{username}" if username else "—"
+        else:
+            username_display = "—"
+        username_escaped = escape(username_display)
         answers_block = self._format_application_answers(application, texts)
         created_at = escape(str(application.created_at))
         return texts.dm_application_item.format(
             full_name=full_name,
+            username=username_escaped,
             user_id=application.user_id,
             answers=answers_block,
             created_at=created_at,
@@ -937,6 +946,7 @@ class DMHandlers:
                     success = await self.storage.add_application(
                         user_id=user.id,
                         full_name=user.full_name or user.username or str(user.id),
+                        username=getattr(user, "username", None),
                         answer=aggregated_answer,
                         language_code=context.user_data.get("preferred_language"),
                         responses=application_responses,

--- a/flyzexbot/localization.py
+++ b/flyzexbot/localization.py
@@ -139,6 +139,7 @@ PERSIAN_TEXTS = TextPack(
     dm_no_pending="درخواستی برای بررسی وجود ندارد.",
     dm_application_item=(
         "<b>کاربر:</b> {full_name} ({user_id})\n"
+        "<b>نام کاربری:</b> {username}\n"
         "<b>پاسخ‌ها:</b>\n{answers}\n"
         "<b>زمان:</b> {created_at}"
     ),
@@ -292,6 +293,7 @@ ENGLISH_TEXTS = TextPack(
     dm_no_pending="There are no applications to review.",
     dm_application_item=(
         "<b>Applicant:</b> {full_name} ({user_id})\n"
+        "<b>Username:</b> {username}\n"
         "<b>Answers:</b>\n{answers}\n"
         "<b>Submitted:</b> {created_at}"
     ),

--- a/flyzexbot/services/storage.py
+++ b/flyzexbot/services/storage.py
@@ -30,6 +30,7 @@ class ApplicationResponse:
 class Application:
     user_id: int
     full_name: str
+    username: Optional[str]
     answer: Optional[str]
     created_at: str
     language_code: Optional[str] = None
@@ -81,6 +82,7 @@ class StorageState:
             applications[int(key)] = Application(
                 user_id=value["user_id"],
                 full_name=value.get("full_name", ""),
+                username=value.get("username"),
                 answer=value.get("answer"),
                 created_at=value.get("created_at", ""),
                 language_code=value.get("language_code"),
@@ -162,6 +164,7 @@ class Storage:
         self,
         user_id: int,
         full_name: str,
+        username: Optional[str],
         answer: Optional[str],
         language_code: Optional[str] = None,
         responses: Optional[List[ApplicationResponse]] = None,
@@ -173,6 +176,7 @@ class Storage:
             self._state.applications[user_id] = Application(
                 user_id=user_id,
                 full_name=full_name,
+                username=username,
                 answer=answer,
                 created_at=timestamp,
                 language_code=language_code,

--- a/tests/test_dm_handlers.py
+++ b/tests/test_dm_handlers.py
@@ -168,6 +168,7 @@ def test_multi_step_application_flow_collects_responses() -> None:
     storage.add_application.assert_awaited_once()
     call_args = storage.add_application.await_args.kwargs
     assert call_args["user_id"] == user.id
+    assert call_args["username"] == user.username
     assert call_args["language_code"] == context.user_data.get("preferred_language")
     responses = call_args["responses"]
     assert len(responses) == 4
@@ -410,6 +411,7 @@ def test_handle_admin_panel_action_view_applications() -> None:
         Application(
             user_id=101,
             full_name="Tester",
+            username="tester",
             answer="Ready to contribute",
             created_at="2024-06-01T12:00:00",
             language_code="fa",
@@ -539,6 +541,7 @@ def test_admin_handles_note_for_approval() -> None:
     application = Application(
         user_id=42,
         full_name="Tester",
+        username="tester",
         answer="I'd love to help",
         created_at="2024-05-01T12:00:00",
         language_code="en",
@@ -593,6 +596,7 @@ def test_admin_handles_skip_for_denial() -> None:
     application = Application(
         user_id=77,
         full_name="کاربر",
+        username="کاربر77",
         answer="",
         created_at="2024-05-02T12:00:00",
         language_code="fa",

--- a/tests/test_html_escaping.py
+++ b/tests/test_html_escaping.py
@@ -66,6 +66,7 @@ async def test_dm_application_rendering_escapes_html() -> None:
     application = Application(
         user_id=42,
         full_name="Eve <Leader>",
+        username="eve<leader>",
         answer="I love & support",
         created_at="2024-01-01T00:00:00",
     )
@@ -82,6 +83,7 @@ async def test_dm_application_rendering_escapes_html() -> None:
     text = chat.messages[0]["text"]
     parse_mode = chat.messages[0]["parse_mode"]
     assert "Eve &lt;Leader&gt;" in text
+    assert "@eve&lt;leader&gt;" in text
     assert "I love &amp; support" in text
     assert parse_mode == ParseMode.HTML
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -38,7 +38,7 @@ def test_application_flow(tmp_path: Path) -> None:
     async def runner() -> None:
         await storage.load()
 
-        added = await storage.add_application(10, "User", "Answer")
+        added = await storage.add_application(10, "User", None, "Answer")
         assert added
         assert storage.has_application(10)
         application = storage.get_application(10)
@@ -56,7 +56,7 @@ def test_application_flow(tmp_path: Path) -> None:
         assert status_after_withdraw.language_code is None
         assert not storage.has_application(10)
 
-        added_again = await storage.add_application(11, "User", "Answer 2")
+        added_again = await storage.add_application(11, "User", None, "Answer 2")
         assert added_again
         popped = await storage.pop_application(11)
         assert popped is not None
@@ -65,7 +65,7 @@ def test_application_flow(tmp_path: Path) -> None:
         assert status_after_review is not None
         assert status_after_review.status == "approved"
 
-        added_with_language = await storage.add_application(12, "User", "Answer 3", language_code="en")
+        added_with_language = await storage.add_application(12, "User", None, "Answer 3", language_code="en")
         assert added_with_language
         application_with_language = storage.get_application(12)
         assert application_with_language is not None

--- a/webapp/server.py
+++ b/webapp/server.py
@@ -29,6 +29,7 @@ def _application_to_dict(application: Application) -> Dict[str, Any]:
     return {
         "user_id": application.user_id,
         "full_name": application.full_name,
+        "username": application.username,
         "answer": application.answer,
         "created_at": application.created_at,
         "language_code": application.language_code,

--- a/webapp/static/app.js
+++ b/webapp/static/app.js
@@ -68,6 +68,15 @@ const loadPendingApplications = async () => {
       title.className = 'item-title';
       title.textContent = `${application.full_name} — ${application.user_id}`;
 
+      const username = document.createElement('span');
+      username.className = 'item-username';
+      if (application.username) {
+        const normalised = application.username.replace(/^@+/, '');
+        username.textContent = `نام کاربری: @${normalised}`;
+      } else {
+        username.textContent = 'نام کاربری: —';
+      }
+
       const answerBlock = document.createElement('div');
       answerBlock.className = 'answer-block';
       const responses = Array.isArray(application.responses) ? application.responses : [];
@@ -104,6 +113,7 @@ const loadPendingApplications = async () => {
       metadata.textContent = parts.join(' | ');
 
       item.appendChild(title);
+      item.appendChild(username);
       item.appendChild(answerBlock);
       if (metadata.textContent) {
         item.appendChild(metadata);

--- a/webapp/static/glass_panel.css
+++ b/webapp/static/glass_panel.css
@@ -136,6 +136,12 @@ body {
   display: block;
 }
 
+.item-username {
+  display: block;
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
 .item-meta {
   font-size: 0.9rem;
   opacity: 0.9;


### PR DESCRIPTION
## Summary
- store applicant usernames alongside applications and surface them in admin review messages
- expose usernames through the web dashboard API and display them in the pending applications list
- update localization strings, styling, and tests to cover the new username field

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e273d821e483248378b95fbb2ef68d