### PR TITLE
Set application timezone to UTC+3:30

### DIFF
--- a/flyzexbot/services/storage.py
+++ b/flyzexbot/services/storage.py
@@ -7,7 +7,7 @@ import logging
 import os
 from collections import Counter
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -19,13 +19,16 @@ from .security import EncryptionManager
 LOGGER = logging.getLogger(__name__)
 
 
-def format_timestamp(dt: Optional[datetime] = None) -> str:
-    """Return a compact, human-friendly UTC timestamp."""
+LOCAL_TIMEZONE = timezone(timedelta(hours=3, minutes=30))
 
-    moment = dt or datetime.now(timezone.utc)
+
+def format_timestamp(dt: Optional[datetime] = None) -> str:
+    """Return a compact, human-friendly timestamp in the local timezone."""
+
+    moment = dt or datetime.now(LOCAL_TIMEZONE)
     if moment.tzinfo is None:
-        moment = moment.replace(tzinfo=timezone.utc)
-    moment = moment.astimezone(timezone.utc)
+        moment = moment.replace(tzinfo=LOCAL_TIMEZONE)
+    moment = moment.astimezone(LOCAL_TIMEZONE)
 
     date_part = moment.strftime("%Y/%m/%d · %H:%M:%S")
     offset = moment.utcoffset()
@@ -50,7 +53,7 @@ def normalize_timestamp(value: str) -> str:
         return value
 
     if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
+        parsed = parsed.replace(tzinfo=LOCAL_TIMEZONE)
     return format_timestamp(parsed)
 
 

--- a/tests/test_dm_handlers.py
+++ b/tests/test_dm_handlers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -10,13 +10,16 @@ from flyzexbot.localization import ENGLISH_TEXTS, PERSIAN_TEXTS
 from flyzexbot.services.storage import (
     Application,
     ApplicationHistoryEntry,
+    LOCAL_TIMEZONE,
     format_timestamp,
 )
 from flyzexbot.ui.keyboards import admin_panel_keyboard, glass_dm_welcome_keyboard
 
 
 def build_ts(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> str:
-    return format_timestamp(datetime(year, month, day, hour, minute, tzinfo=timezone.utc))
+    return format_timestamp(
+        datetime(year, month, day, hour, minute, tzinfo=LOCAL_TIMEZONE)
+    )
 
 
 MODERN_TS = build_ts(2024, 6, 1, 12, 0)

--- a/tests/test_html_escaping.py
+++ b/tests/test_html_escaping.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -16,7 +16,7 @@ def anyio_backend() -> str:
 
 from flyzexbot.handlers.dm import DMHandlers
 from flyzexbot.handlers.group import GroupHandlers
-from flyzexbot.services.storage import Application, format_timestamp
+from flyzexbot.services.storage import Application, LOCAL_TIMEZONE, format_timestamp
 
 
 class DummyChat:
@@ -69,7 +69,7 @@ async def test_dm_application_rendering_escapes_html() -> None:
         full_name="Eve <Leader>",
         username="eve<leader>",
         answer="I love & support",
-        created_at=format_timestamp(datetime(2024, 1, 1, tzinfo=timezone.utc)),
+        created_at=format_timestamp(datetime(2024, 1, 1, tzinfo=LOCAL_TIMEZONE)),
     )
     storage = DMStorageStub(application)
     handlers = DMHandlers(storage, owner_id=1)


### PR DESCRIPTION
## Summary
- update storage timestamp formatting to use a UTC+3:30 local timezone helper
- adjust tests to rely on the shared timezone constant for constructing timestamps

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e277c2392083249fabc3b4a84ba588