### PR TITLE
Add admin management tools to webapp

### DIFF
--- a/flyzexbot/localization.py
+++ b/flyzexbot/localization.py
@@ -77,12 +77,22 @@ class TextPack:
     dm_admin_panel_intro: str
     dm_admin_panel_view_applications_button: str
     dm_admin_panel_view_members_button: str
-    dm_admin_panel_add_admin_button: str
+    dm_admin_panel_manage_admins_button: str
     dm_admin_panel_more_tools_button: str
     dm_admin_panel_insights_button: str
     dm_admin_panel_back_button: str
     dm_admin_panel_members_header: str
     dm_admin_panel_members_empty: str
+    dm_admin_manage_title: str
+    dm_admin_manage_intro: str
+    dm_admin_manage_add_button: str
+    dm_admin_manage_remove_button: str
+    dm_admin_manage_list_button: str
+    dm_admin_manage_back_button: str
+    dm_admin_manage_list_header: str
+    dm_admin_manage_list_empty: str
+    dm_admin_manage_list_entry: str
+    dm_admin_manage_list_unknown: str
     dm_admin_panel_add_admin_prompt: str
     dm_admin_panel_more_tools_text: str
     dm_admin_panel_more_tools_no_webapp: str
@@ -215,12 +225,22 @@ PERSIAN_TEXTS = TextPack(
     ),
     dm_admin_panel_view_applications_button="مشاهده درخواست‌ها",
     dm_admin_panel_view_members_button="اعضای تایید‌شده",
-    dm_admin_panel_add_admin_button="افزودن ادمین جدید",
+    dm_admin_panel_manage_admins_button="مدیریت ادمین‌ها",
     dm_admin_panel_more_tools_button="ابزارهای بیشتر",
     dm_admin_panel_insights_button="گزارش‌ها و تحلیل‌ها",
     dm_admin_panel_back_button="بازگشت به خانه",
     dm_admin_panel_members_header="✅ اعضای تایید‌شده ({count} نفر):\n{members}",
     dm_admin_panel_members_empty="هیچ عضوی تأیید نشده است.",
+    dm_admin_manage_title="<b>🛡️ مدیریت ادمین‌ها</b>",
+    dm_admin_manage_intro="از گزینه‌های زیر برای افزودن، حذف یا مشاهده فهرست ادمین‌ها استفاده کنید.",
+    dm_admin_manage_add_button="افزودن ادمین",
+    dm_admin_manage_remove_button="حذف ادمین",
+    dm_admin_manage_list_button="نمایش فهرست ادمین‌ها",
+    dm_admin_manage_back_button="بازگشت به پنل اصلی",
+    dm_admin_manage_list_header="<b>ادمین‌های فعال:</b>",
+    dm_admin_manage_list_empty="هیچ ادمینی ثبت نشده است.",
+    dm_admin_manage_list_entry="• {display} — شناسه: <code>{user_id}</code>",
+    dm_admin_manage_list_unknown="بدون نام",
     dm_admin_panel_add_admin_prompt="شناسه عددی کاربر موردنظر را ارسال کنید.",
     dm_admin_panel_more_tools_text=(
         "✨ می‌توانید از نسخه وب برای مدیریت کامل‌تر استفاده کنید:\n"
@@ -369,12 +389,22 @@ ENGLISH_TEXTS = TextPack(
     ),
     dm_admin_panel_view_applications_button="View applications",
     dm_admin_panel_view_members_button="Approved members",
-    dm_admin_panel_add_admin_button="Add a new admin",
+    dm_admin_panel_manage_admins_button="Manage admins",
     dm_admin_panel_more_tools_button="More tools",
     dm_admin_panel_insights_button="Analytics & reports",
     dm_admin_panel_back_button="Back to welcome",
     dm_admin_panel_members_header="✅ Approved members ({count}):\n{members}",
     dm_admin_panel_members_empty="No members have been approved yet.",
+    dm_admin_manage_title="<b>🛡️ Admin management</b>",
+    dm_admin_manage_intro="Use the buttons below to add, remove, or review the current admins.",
+    dm_admin_manage_add_button="Add admin",
+    dm_admin_manage_remove_button="Remove admin",
+    dm_admin_manage_list_button="Show admin list",
+    dm_admin_manage_back_button="Back to main panel",
+    dm_admin_manage_list_header="<b>Current admins:</b>",
+    dm_admin_manage_list_empty="No admins have been registered yet.",
+    dm_admin_manage_list_entry="• {display} — ID: <code>{user_id}</code>",
+    dm_admin_manage_list_unknown="No name",
     dm_admin_panel_add_admin_prompt=(
         "Send the numeric user ID of the member you want to promote."
         "\nSend /cancel to abort."

--- a/flyzexbot/ui/keyboards.py
+++ b/flyzexbot/ui/keyboards.py
@@ -83,8 +83,8 @@ def admin_panel_keyboard(
         ],
         [
             InlineKeyboardButton(
-                text=f"➕ {text_pack.dm_admin_panel_add_admin_button}",
-                callback_data="admin_panel:add_admin",
+                text=f"🧑‍💼 {text_pack.dm_admin_panel_manage_admins_button}",
+                callback_data="admin_panel:manage_admins",
             )
         ],
         [
@@ -121,6 +121,38 @@ def admin_panel_keyboard(
         ]
     )
     return InlineKeyboardMarkup(rows)
+
+
+def admin_management_keyboard(texts: TextPack | None = None) -> InlineKeyboardMarkup:
+    text_pack = texts or PERSIAN_TEXTS
+    return InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton(
+                    text=f"➕ {text_pack.dm_admin_manage_add_button}",
+                    callback_data="admin_panel:manage_admins:add",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text=f"➖ {text_pack.dm_admin_manage_remove_button}",
+                    callback_data="admin_panel:manage_admins:remove",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text=f"📋 {text_pack.dm_admin_manage_list_button}",
+                    callback_data="admin_panel:manage_admins:list",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text=f"⬅️ {text_pack.dm_admin_manage_back_button}",
+                    callback_data="admin_panel:manage_admins:back",
+                )
+            ],
+        ]
+    )
 
 
 def application_review_keyboard(user_id: int, texts: TextPack | None = None) -> InlineKeyboardMarkup:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -22,10 +22,15 @@ def test_admin_management(tmp_path: Path) -> None:
         await storage.load()
 
         assert not storage.list_admins()
-        assert await storage.add_admin(1)
+        assert await storage.add_admin(1, username="@founder", full_name="Founder")
+        details = storage.get_admin_details()
+        assert details == [
+            {"user_id": 1, "username": "founder", "full_name": "Founder"}
+        ]
         assert not await storage.add_admin(1)
         assert storage.is_admin(1)
         assert await storage.remove_admin(1)
+        assert storage.get_admin_details() == []
         assert not await storage.remove_admin(1)
 
     asyncio.run(runner())

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -16,6 +16,7 @@
       <div class="button-grid">
         <button type="button" data-view="overview" class="active">درخواست عضویت</button>
         <button type="button" data-view="pending">بررسی درخواست‌ها</button>
+        <button type="button" data-view="admins">مدیریت ادمین‌ها</button>
         <button type="button" data-view="xp">نمایش لیدربورد XP</button>
         <button type="button" data-view="cups">نمایش جام‌ها</button>
         <button type="button" data-view="analytics">گزارش مدیریتی</button>
@@ -32,6 +33,65 @@
           <h2>درخواست‌های در انتظار بررسی</h2>
           <p id="pending-status" class="status">برای مشاهده داده‌ها روی دکمه بالا کلیک کنید.</p>
           <ul id="pending-list" class="data-list" aria-live="polite"></ul>
+        </section>
+        <section id="view-admins" class="view">
+          <h2>مدیریت ادمین‌ها</h2>
+          <div class="admin-actions">
+            <form id="admin-add-form" class="inline-form card-form">
+              <h3>افزودن ادمین جدید</h3>
+              <label for="admin-add-user-id">شناسه کاربری (User ID)
+                <input
+                  id="admin-add-user-id"
+                  name="user_id"
+                  type="number"
+                  inputmode="numeric"
+                  required
+                  placeholder="مثال: 123456789"
+                />
+              </label>
+              <label for="admin-add-username">نام کاربری تلگرام (اختیاری)
+                <input
+                  id="admin-add-username"
+                  name="username"
+                  type="text"
+                  inputmode="text"
+                  placeholder="مثال: @flyzex"
+                />
+              </label>
+              <label for="admin-add-full-name">نام نمایشی (اختیاری)
+                <input
+                  id="admin-add-full-name"
+                  name="full_name"
+                  type="text"
+                  inputmode="text"
+                  placeholder="مثال: تیم مدیریت"
+                />
+              </label>
+              <button type="submit">افزودن</button>
+              <p id="admin-add-status" class="form-status" aria-live="polite">
+                برای افزودن ادمین شناسه کاربری را وارد کنید.
+              </p>
+            </form>
+            <form id="admin-remove-form" class="inline-form card-form">
+              <h3>حذف ادمین موجود</h3>
+              <label for="admin-remove-user-id">شناسه کاربری (User ID)
+                <input
+                  id="admin-remove-user-id"
+                  name="user_id"
+                  type="number"
+                  inputmode="numeric"
+                  required
+                  placeholder="مثال: 123456789"
+                />
+              </label>
+              <button type="submit">حذف</button>
+              <p id="admin-remove-status" class="form-status" aria-live="polite">
+                شناسه ادمین مورد نظر را برای حذف وارد کنید.
+              </p>
+            </form>
+          </div>
+          <p id="admins-status" class="status" aria-live="polite">فهرست ادمین‌های ثبت شده در این بخش نمایش داده می‌شود.</p>
+          <ul id="admins-list" class="data-list" aria-live="polite"></ul>
         </section>
         <section id="view-xp" class="view">
           <h2>لیدربورد تجربه (XP)</h2>

--- a/webapp/static/glass_panel.css
+++ b/webapp/static/glass_panel.css
@@ -177,6 +177,39 @@ body {
   color: #fff;
 }
 
+.admin-actions {
+  display: grid;
+  gap: 1.25rem;
+  margin-top: 1.25rem;
+  grid-template-columns: 1fr;
+}
+
+.card-form {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 16px;
+  padding: 1rem 1.25rem;
+}
+
+.card-form h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.card-form button {
+  justify-self: stretch;
+}
+
+.form-status {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.card-form .form-status {
+  margin-top: 0.5rem;
+}
+
 .podium-list {
   list-style: decimal;
   margin: 0.75rem 0 0;
@@ -190,5 +223,15 @@ body {
 
   .glass-panel h1 {
     font-size: 1.5rem;
+  }
+
+  .admin-actions {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 720px) {
+  .admin-actions {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }


### PR DESCRIPTION
## Summary
- persist optional admin profile metadata in storage and expose admin details for the web panel
- add FastAPI endpoints for listing, creating, and deleting admins
- extend the glass panel UI with an admin management view including add/remove forms and styling updates

## Testing
- pytest tests/test_storage.py

------
https://chatgpt.com/codex/tasks/task_b_68e27980554c8324bff31b1df249022c