### PR TITLE
Add automatic SQLite backup generation for storage snapshots

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -39,7 +39,11 @@ async def build_application(settings: Settings) -> None:
     await analytics.start()
 
     encryption = EncryptionManager(settings.get_secret_key())
-    storage = Storage(settings.storage.path, encryption)
+    storage = Storage(
+        settings.storage.path,
+        encryption,
+        backup_path=settings.storage.backup_path,
+    )
     await storage.load()
 
     if settings.telegram.owner_id not in storage.list_admins():

--- a/config/settings.example.yaml
+++ b/config/settings.example.yaml
@@ -12,6 +12,7 @@ cups:
   leaderboard_size: 5
 storage:
   path: data/storage.json.enc
+  backup_path: data/storage.sqlite
 logging:
   level: INFO
   file: logs/bot.log

--- a/flyzexbot/config.py
+++ b/flyzexbot/config.py
@@ -31,6 +31,7 @@ class CupConfig:
 @dataclass
 class StorageConfig:
     path: Path
+    backup_path: Optional[Path] = None
 
 
 @dataclass
@@ -107,6 +108,7 @@ class Settings:
 
         storage = StorageConfig(
             path=Path(data["storage"]["path"]),
+            backup_path=Path(data["storage"]["backup_path"]) if data["storage"].get("backup_path") else None,
         )
 
         logging_cfg = data.get("logging", {})

--- a/webapp/server.py
+++ b/webapp/server.py
@@ -49,7 +49,11 @@ def _normalize_user_id(value: str) -> int | str:
 async def lifespan(app: FastAPI):
     settings = Settings.load(_resolve_config_path())
     encryption = EncryptionManager(settings.get_secret_key())
-    storage = Storage(settings.storage.path, encryption)
+    storage = Storage(
+        settings.storage.path,
+        encryption,
+        backup_path=settings.storage.backup_path,
+    )
     await storage.load()
 
     app.state.settings = settings


### PR DESCRIPTION
## Summary
- add an optional SQLite backup path to the storage configuration and wire it into the bot and webapp
- export every storage snapshot to a structured SQLite database alongside the encrypted JSON file
- document the backup path in the example settings and add unit coverage for the new backup output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e281c0937483248e986e541afa5e8e